### PR TITLE
Export error for empty result URL

### DIFF
--- a/bulk.go
+++ b/bulk.go
@@ -15,15 +15,18 @@ import (
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/r0busta/go-shopify-graphql-model/v3/graph/model"
-	"github.com/r0busta/go-shopify-graphql/v6/rand"
-	"github.com/r0busta/go-shopify-graphql/v6/utils"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/guregu/null.v4"
+
+	"github.com/r0busta/go-shopify-graphql/v6/rand"
+	"github.com/r0busta/go-shopify-graphql/v6/utils"
 )
 
 const (
 	edgesFieldName = "Edges"
 	nodeFieldName  = "Node"
+
+	ErrorOperationResultURLEmpty = "operation result URL is empty"
 )
 
 //go:generate mockgen -destination=./mock/bulk_service.go -package=mock . BulkOperationService
@@ -204,7 +207,7 @@ func (s *BulkOperationServiceOp) BulkQuery(query string, out interface{}) error 
 	}
 
 	if url == nil || *url == "" {
-		return fmt.Errorf("Operation result URL is empty")
+		return fmt.Errorf(ErrorOperationResultURLEmpty)
 	}
 
 	filename := fmt.Sprintf("%s%s", rand.String(10), ".jsonl")


### PR DESCRIPTION
This will allow us to specifically look for this error when we're calling the package's functions in external code blocks. Just exporting this specific error for now to fast track work on our projects, but ideally all static errors at least for bulk query functions will be exported.
